### PR TITLE
Added a 25th hour so that events started at 11:55pm show up in the 

### DIFF
--- a/Ext.ux.TouchCalendarEvents/Ext.ux.TouchCalendarWeekEvents.js
+++ b/Ext.ux.TouchCalendarEvents/Ext.ux.TouchCalendarWeekEvents.js
@@ -82,7 +82,8 @@ renderEventBars: function(store){
 	        //calculate where it should be in the day roughly      
     	    //FIXME: figure out how to get the month bar height and the size of the text for the day numbers
         	//20 is just a rough guess that seems to work decently.  
-	        var hour = (bodyHeight-20)/24;
+        	//we use 25 here so that events schedueled for 11:55 show up on the calendar
+	        var hour = (bodyHeight-20)/25;
     	    var minute = hour/60;
         	var startHour = record.data.Record.get(this.getPlugin().getStartEventField()).getHours();
 	        var startMinutes = record.data.Record.get(this.getPlugin().getStartEventField()).getMinutes();


### PR DESCRIPTION
calendar in week view. 

to test this you will need to pull this change into iPam on the calendar-fix branch.

once that is done then open the calendar to week view and either create or find an event scheduled for 11:55pm. The event should show up a few pixels above the bottom of the calendar.

This is for iPam issue https://github.com/granduke/iPam/issues/556
