### PR TITLE
Added the color green to the event bar when an event is selected.

### DIFF
--- a/Ext.ux.TouchCalendarEvents/resources/css/Ext.ux.TouchCalendarEvents.css
+++ b/Ext.ux.TouchCalendarEvents/resources/css/Ext.ux.TouchCalendarEvents.css
@@ -16,7 +16,7 @@
 }
 /* line 23, ../scss/Ext.ux.TouchCalendarEvents.scss */
 .touch-calendar-view div.event-bar.event-bar-selected {
-  background-color: #1a222d;
+  background-color: #004400 !important;
 }
 /* line 28, ../scss/Ext.ux.TouchCalendarEvents.scss */
 .touch-calendar-view div.event-bar.wrap-end {

--- a/Ext.ux.TouchCalendarEvents/resources/scss/Ext.ux.TouchCalendarEvents.scss
+++ b/Ext.ux.TouchCalendarEvents/resources/scss/Ext.ux.TouchCalendarEvents.scss
@@ -21,7 +21,7 @@
 	
 		&.event-bar-selected
 		{
-			background-color: darken($bg-color, 45%);
+			background-color: #000000 !important;
 		}
 			
 		&.wrap-end


### PR DESCRIPTION
Issue #566: The user does not get any feedback when pressing on the calendar events

To test:

On Month/Week/Day View: Click on any event. It must turn green (just a generic color to match our others bars shade). When the user closes the Event View window, the event bar turns back to its original color after a quick time.

Please, close the issue #566 on iPam. 
